### PR TITLE
Revert "CAPI-408: Strict cardholder name validation (#60)"

### DIFF
--- a/apps/capi/test/capi_payment_resources_tests_SUITE.erl
+++ b/apps/capi/test/capi_payment_resources_tests_SUITE.erl
@@ -26,7 +26,6 @@
 
 -export([
     create_visa_payment_resource_ok_test/1,
-    create_payment_resource_invalid_cardholder_test/1,
     create_visa_with_empty_cvv_ok_test/1,
     create_visa_with_wrong_cvv_test/1,
     create_visa_with_wrong_cardnumber_test/1,
@@ -98,7 +97,6 @@ groups() ->
         {payment_resources, [],
             [
                 create_visa_payment_resource_ok_test,
-                create_payment_resource_invalid_cardholder_test,
                 create_visa_with_empty_cvv_ok_test,
                 create_visa_with_wrong_cvv_test,
                 create_visa_with_wrong_cardnumber_test,
@@ -218,29 +216,6 @@ create_visa_payment_resource_ok_test(Config) ->
         },
         <<"clientInfo">> => ClientInfo
     }).
-
--spec create_payment_resource_invalid_cardholder_test(_) ->
-    _.
-create_payment_resource_invalid_cardholder_test(Config) ->
-    ClientInfo = #{<<"fingerprint">> => <<"test fingerprint">>},
-    PaymentTool = #{
-        <<"paymentToolType">> => <<"CardData">>,
-        <<"cardNumber">> => <<"4111111111111111">>,
-        <<"expDate">> => <<"08/27">>,
-        <<"cvv">> => <<"232">>
-    },
-    {error, {request_validation_failed, _}} = capi_client_tokens:create_payment_resource(?config(context, Config),
-        #{
-            <<"paymentTool">> => PaymentTool#{<<"cardHolder">> => <<"4111111111111111">>},
-            <<"clientInfo">> => ClientInfo
-        }
-    ),
-    {error, {request_validation_failed, _}} = capi_client_tokens:create_payment_resource(?config(context, Config),
-        #{
-            <<"paymentTool">> => PaymentTool#{<<"cardHolder">> => <<"Вася Иванов"/utf8>>},
-            <<"clientInfo">> => ClientInfo
-        }
-    ).
 
 -spec create_visa_with_empty_cvv_ok_test(_) ->
     _.


### PR DESCRIPTION
This reverts commit 4ec0cc146e1df96a0de3e375c31c57f958bf10bd.